### PR TITLE
Status Code not returning HTTP Error

### DIFF
--- a/peerfinder/peerfinder.py
+++ b/peerfinder/peerfinder.py
@@ -364,7 +364,7 @@ def getPeeringDB(ASN: str) -> Dict:
     r = requests.get(pdb_url)
     if r.status_code != requests.status_codes.codes.ALL_OK:
         print("Got unexpected status code, exiting")
-        print("%s - %s" % (r.status, r.text))
+        print("%s - %s" % (r.status_code, r.text))
         exit(1)
     if len(r.json()["data"]) != 1:
         print(


### PR DESCRIPTION
When PeerFinder receives an error from the PeeringDB API, it's supposed to print the return error out on the console. It crashes instead:

    [tw-mbp-chaynes PeerFinder (api-http-error)]$ python peerfinder/peerfinder.py --asn 13414 191 --ix --private
    Fetching PeeringDB info for 13414
    Got unexpected status code, exiting
    Traceback (most recent call last):
      File "peerfinder/peerfinder.py", line 378, in <module>
        main()
      File "peerfinder/peerfinder.py", line 76, in main
        [pdata.update({i: getPeeringDB(i)}) for i in args.asn]
      File "peerfinder/peerfinder.py", line 76, in <listcomp>
        [pdata.update({i: getPeeringDB(i)}) for i in args.asn]
      File "peerfinder/peerfinder.py", line 367, in getPeeringDB
        print("%s - %s" % (r.status, r.text))
    AttributeError: 'Response' object has no attribute 'status'

For some reason, this crashes on me, and it appears that the status code variable isn't correct.

After making the proposed change below, the error is much friendlier:

    [tw-mbp-chaynes PeerFinder (api-http-error)]$ python peerfinder/peerfinder.py --asn 3356 191 --ix --private
    Fetching PeeringDB info for 3356
    Got unexpected status code, exiting
    401 - {"meta": {"error": "Invalid username/password."}}