### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argparse
 requests
 prettytable
+dataclasses


### PR DESCRIPTION
Include dataclasses in the requirements, since it is not installed by default in python 3.6, and it's needed to be executed in this environment